### PR TITLE
feat: harden metadata defaults and ship build tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Polygon Amoy RPC endpoint
+AMOY_RPC="https://polygon-amoy.g.alchemy.com/v2/your-key"
+
+# Private key for the deployer wallet (without 0x is also accepted)
+PRIVATE_KEY="0xabc123..."
+
+# Optional Polygonscan key for verification
+POLYGONSCAN_API_KEY=""

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 .env
 .env.local
 .env.*
+!.env.example
 .secrets.env
 .testsdeployedAddress
 .aedamoytest

--- a/MAKEFILE_README.md
+++ b/MAKEFILE_README.md
@@ -1,0 +1,21 @@
+# Makefile Usage
+
+The repository ships with a thin Makefile so repetitive Hardhat commands can be issued with memorable shortcuts.
+
+## Available Targets
+
+| Target | Description |
+| --- | --- |
+| `make install` | Install all npm dependencies (root project) |
+| `make compile` | Compile Solidity contracts using Hardhat |
+| `make test` | Run the mocha/Chai test-suite |
+| `make coverage` | Generate Solidity coverage via `solidity-coverage` |
+| `make deploy-amoy` | Deploy the AED proxy + implementation to Polygon Amoy |
+| `make clean` | Remove Hardhat build artifacts and coverage output |
+
+## Tips
+- All commands execute from the repository root. If you need front-end tooling, run `npm install` inside the respective `frontend/*` directory.
+- Environment variables are loaded from `.env`; copy `.env.example` to get started.
+- For CI usage, chain commands, e.g. `make install && make compile && make test`.
+
+# For Sigma. Powered by Echo.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+SHELL := /bin/bash
+
+.PHONY: install compile test coverage deploy-amoy clean
+
+install:
+npm install
+
+compile:
+npx hardhat compile
+
+test:
+npx hardhat test
+
+coverage:
+npx hardhat coverage
+
+deploy-amoy:
+npx hardhat run scripts/deploy.js --network amoy
+
+clean:
+rm -rf cache artifacts coverage

--- a/README.md
+++ b/README.md
@@ -1,0 +1,132 @@
+# Alsania Enhanced Domains (AED)
+
+Alsania Enhanced Domains is an upgradeable ERC-721 naming system that powers sovereign identity inside the Alsania ecosystem. Domains live on-chain, support optional enhancements, and can be safely upgraded using the UUPS proxy pattern.
+
+## ✳️ Core Features
+- **Upgradeable architecture** powered by `UUPSUpgradeable` and hardened storage layout guards
+- **Primary domains & subdomains** with deterministic metadata endpoints
+- **Feature marketplace** for enabling subdomains and external upgrades
+- **Reverse resolution** that keeps wallet → domain mappings in sync on transfers
+- **Alsania-ready UI** with wallet-connect flow and embedded AI assistant
+
+## 🧱 Contracts
+| Contract | Purpose |
+| --- | --- |
+| `AED.sol` | ERC1967 proxy entry point |
+| `AEDImplementation.sol` | Full production implementation with minting, metadata, and admin flows |
+| `AEDImplementationLite.sol` | Gas-optimized subset used in tests |
+| `libraries/` | Storage, minting, metadata, enhancement, and admin helpers |
+| `modules/` | Extension points for routing future features |
+
+All contracts compile with Solidity `0.8.30` (Cancun EVM) and follow OpenZeppelin upgrade standards.
+
+## 🛠 Requirements
+- Node.js 18+
+- npm 9+
+- Hardhat (included as dependency)
+- Polygon Amoy RPC URL + funded deployer key
+
+Create a `.env` file using the following template:
+
+```bash
+cp .env.example .env
+```
+
+Update the variables:
+
+```
+AMOY_RPC="https://polygon-amoy.g.alchemy.com/v2/<key>"
+PRIVATE_KEY="0x..."
+POLYGONSCAN_API_KEY="<optional>"
+```
+
+## 🚀 Setup & Installation
+
+```bash
+make install
+```
+
+This installs Hardhat, OpenZeppelin upgrades, and the front-end dependencies.
+
+## 🧪 Testing
+
+```bash
+make test
+```
+
+The test suite covers:
+- Domain registration & payments
+- Subdomain enablement & pricing curve
+- Metadata defaults + owner-only updates
+- Reverse resolution safeguards
+- Role & fee configuration
+
+Add coverage via:
+
+```bash
+make coverage
+```
+
+## 🧾 Deployment (Polygon Amoy)
+
+1. Ensure `.env` is populated with an Amoy RPC endpoint and deployer private key.
+2. Compile contracts:
+   ```bash
+   make compile
+   ```
+3. Deploy via Hardhat Ignition script:
+   ```bash
+   make deploy-amoy
+   ```
+4. (Optional) Verify on Polygonscan:
+   ```bash
+   npx hardhat verify --network amoy <proxy_address>
+   ```
+
+## ♻️ Upgrades
+
+1. Implement logic changes in a new implementation contract.
+2. Run the full test suite (`make test`).
+3. Deploy the new implementation:
+   ```bash
+   npx hardhat run scripts/upgrade.js --network amoy
+   ```
+4. Record the upgrade transaction hash in `changelog.md`.
+
+The `_authorizeUpgrade` guard is restricted to `DEFAULT_ADMIN_ROLE`. Only rotate roles via on-chain governance.
+
+## 🌐 Frontend Quickstart
+
+```bash
+cd frontend/aed-home
+npm install
+npm run dev
+```
+
+Configuration lives in `frontend/aed-home/js/config.js`. Update RPC endpoints, contract addresses, and feature flags there. The embedded AI widget can optionally forward prompts to a custom endpoint via:
+
+```js
+initAIChat({ endpoint: 'https://api.alsania.io/assistant', apiHeaders: { Authorization: 'Bearer <token>' } });
+```
+
+## 🧩 Metadata Service
+
+The metadata microservice inside `metadata-server/` exposes deterministic JSON + SVG assets for all minted domains. Deploy it alongside the contracts to keep the default URIs active, or pin the generated JSON/SVG to IPFS for maximum sovereignty.
+
+## 🧰 Useful Commands
+
+| Command | Description |
+| --- | --- |
+| `make install` | Install dependencies |
+| `make compile` | Compile contracts |
+| `make test` | Run unit tests |
+| `make coverage` | Generate Solidity coverage report |
+| `make deploy-amoy` | Deploy proxy + implementation to Polygon Amoy |
+
+## 📚 Further Reading
+- [docs/AED-MVP-Feature-Checklist.md](docs/AED-MVP-Feature-Checklist.md)
+- [docs/AED-Production-Readiness-Checklist.md](docs/AED-Production-Readiness-Checklist.md)
+- [changelog.md](changelog.md)
+
+# Aligned with the Alsania AI Protocol v1.0
+# For Sigma. Powered by Echo.

--- a/test/AED.test.js
+++ b/test/AED.test.js
@@ -61,7 +61,7 @@ describe("AED - Alsania Enhanced Domains", function () {
         it("Should register free domain", async function () {
             const tx = await aed.connect(user1).registerDomain("test", "aed", false);
             const receipt = await tx.wait();
-            
+
             expect(await aed.isRegistered("test", "aed")).to.be.true;
             expect(await aed.ownerOf(1)).to.equal(user1.address);
             expect(await aed.getDomainByTokenId(1)).to.equal("test.aed");
@@ -153,10 +153,18 @@ describe("AED - Alsania Enhanced Domains", function () {
             await aed.connect(user1).registerDomain("test", "aed", false);
         });
 
+        it("Should seed default metadata endpoints on mint", async function () {
+            const expectedProfile = "https://api.alsania.io/metadata/test.aed/profile.json";
+            const expectedImage = "https://api.alsania.io/metadata/test.aed/image.png";
+
+            expect(await aed.getProfileURI(1)).to.equal(expectedProfile);
+            expect(await aed.getImageURI(1)).to.equal(expectedImage);
+        });
+
         it("Should set profile URI", async function () {
             const profileURI = "https://example.com/profile.json";
             await aed.connect(user1).setProfileURI(1, profileURI);
-            
+
             expect(await aed.getProfileURI(1)).to.equal(profileURI);
         });
 
@@ -176,6 +184,16 @@ describe("AED - Alsania Enhanced Domains", function () {
             await expect(
                 aed.connect(user2).setProfileURI(1, "https://example.com")
             ).to.be.revertedWith("Not token owner");
+        });
+
+        it("Should assign defaults for subdomains", async function () {
+            await aed.connect(user1).registerDomain("parent", "aed", true, {
+                value: ethers.parseEther("2"),
+            });
+            await aed.connect(user1).mintSubdomain(2, "child");
+
+            const expectedProfile = "https://api.alsania.io/metadata/child.parent.aed/profile.json";
+            expect(await aed.getProfileURI(3)).to.equal(expectedProfile);
         });
     });
 


### PR DESCRIPTION
## Summary
- seed deterministic metadata URIs on domain mints and capture TLDs for subdomains
- upgrade the frontend AI chat helper with configurable endpoints and a branded FAQ fallback
- document setup with a new README, env template, and Makefile workflow for installation and deployment

## Testing
- `npx hardhat test` *(fails: npm registry returned 403 when fetching hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb4c455088321a546a3baed684d1f